### PR TITLE
Added start-account-storage to process iframe messages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,40 @@
+{
+  "extends": ["eslint:recommended"],
+  "env": {
+    "browser": true,
+    "mocha": true,
+    "node": true,
+    "amd": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 3
+  },
+  "rules": {
+    "camelcase": 2,
+    "complexity": [2, 6],
+    "curly": 2,
+    "dot-notation": 0,
+    "guard-for-in": 2,
+    "new-cap": [2, { properties: false }],
+    "no-caller": 2,
+    "no-empty": 2,
+    "no-eval": 2,
+    "no-implied-eval": 2,
+    "no-multi-str": 0,
+    "no-new": 2,
+    "no-plusplus": 0,
+    "no-undef": 2,
+    "no-use-before-define": [2, "nofunc"],
+    "no-unused-expressions": [2, { allowShortCircuit: true, allowTernary: true }],
+    "no-unused-vars": [2, { "args": "none" }],
+    "max-depth": [2, 2],
+    "max-len": [2, 120],
+    "max-params": [2, 5],
+    "max-statements": [2, 10],
+    "quotes": [2, "single"],
+    "semi": 2,
+    "strict": 0,
+    "wrap-iife": [2, "any"]
+  },
+  "root": true
+}

--- a/discovery/iframe.html
+++ b/discovery/iframe.html
@@ -6,49 +6,11 @@
       <title></title>
       <meta name="description" content="">
       <meta name="viewport" content="width=device-width, initial-scale=1">
+      <script src="/lib/start-account-storage.js"></script>
   </head>
   <body>
     <script>
-      var allowedOriginSuffix = '.okta.io:8081';
-
-      function isInIframe() {
-          try {
-              return window.self !== window.top;
-          } catch (e) {
-              return true;
-          }
-      }
-
-      function receiveMessage(event) {
-        console.log('received message from %s => %o', event.origin, event);
-        // Only process events from whitelisted origins!
-        if (event.origin.startsWith('http://') && (event.origin.endsWith(allowedOriginSuffix))) {
-          if (event.data && event.data.type) {
-            if (event.data.type === 'getAccounts') {
-              var accounts = window.localStorage.getItem('okta_accounts');
-              accounts = accounts ? JSON.parse(accounts) : {};
-              console.log('saved accounts %o', accounts);
-              var parentWindow = window.isInIframe() ? window.parent : window.opener;
-              parentWindow.postMessage(accounts, event.origin);
-            } else if (event.data.type === 'login') {
-              var accounts = window.localStorage.getItem('okta_accounts');
-              accounts = accounts ? JSON.parse(accounts) : {};
-              accounts[event.origin] = {
-                login: event.data.login,
-                displayName: event.data.displayName,
-                lastUpdated: new Date().toISOString()
-              }
-              accounts = JSON.stringify(accounts);
-              console.log('updated accounts %s', accounts);
-              window.localStorage.setItem('okta_accounts', accounts);
-              event.source.postMessage({
-                messageType: 'processed_login'
-              }, event.origin);
-            }
-          }
-        }
-      }
-
-      window.addEventListener("message", receiveMessage, false);
+      var trustedRootDomains = ['okta.io:8081'];
+      startAccountStorage(trustedRootDomains);
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -23,13 +23,15 @@
           </p>
           <p>
             <input id="add-account" type="button" value="Add Account">
+            <input id="delete-account" type="button" value="Delete Account">
             <input id="refresh-accounts" type="button" value="Refresh Accounts">
           </p>
         </div>
         <div id="content"></div>
         <script>
-        var iframeOrigin = 'http://accounts.okta.io:8081';
+        var iframeOrigin = 'https://accounts.okta.io:8081';
         var samlRequest = parseSamlRequest();
+        var latestAccounts = [];
         window.addEventListener("message", receiveMessage, false);
 
         $(document).ready(function() {
@@ -40,6 +42,10 @@
             login($('#account-login').val(), $('#account-display-name').val());
             $('#account-login').val('');
             $('#account-display-name').val('');
+          });
+
+          $('#delete-account').click(function() {
+            deleteAccount();
           });
 
           $('#refresh-accounts').click(function() {
@@ -119,37 +125,51 @@
 
         function login(login, displayName) {
           var iframeWin = document.getElementById("account-chooser-iframe").contentWindow;
-          console.log('posting message to iframe');
-          iframeWin.postMessage({
-            type: 'login',
+          var message = {
+            messageType: 'login',
             login: login,
             displayName: displayName
-          }, iframeOrigin);
+          };
+          console.log('posting message to iframe:', message);
+          iframeWin.postMessage(message, iframeOrigin);
         }
 
         function refreshAccounts() {
           var iframeWin = document.getElementById("account-chooser-iframe").contentWindow;
-          console.log('posting message to iframe');
-          iframeWin.postMessage({
-            type: 'getAccounts'
-          }, iframeOrigin);
+          var message = { messageType: 'get_accounts' };
+          console.log('posting message to iframe:', message);
+          iframeWin.postMessage(message, iframeOrigin);
         }
 
         function deleteAccount() {
+          var accountId = window.prompt(
+            'Which accountId would you like to delete?\n\n' +
+            latestAccounts.map(function (account) {
+              return account.id;
+            }).join('\n')
+          );
           var iframeWin = document.getElementById("account-chooser-iframe").contentWindow;
-          console.log('posting message to iframe');
-          iframeWin.postMessage({
-            type: 'deleteAccount'
-          }, iframeOrigin);
+          var message = {
+            messageType: 'remove_account',
+            accountId: accountId
+          };
+          console.log('posting message to iframe:', message);
+          iframeWin.postMessage(message, iframeOrigin);
         }
 
         function receiveMessage(event) {
-          console.log('received message from iframe', event);
-          if (event.origin === iframeOrigin && event.data) {
-            if (samlRequest.acsUrl) {
+          if (event.origin !== iframeOrigin || !event.data) {
+            return;
+          }
+
+          console.log('received message from iframe (' + event.origin + '):', event.data);
+
+          if (event.data.messageType === 'processed_get_accounts') {
+            latestAccounts = event.data.accounts;
+            if (samlRequest && samlRequest.acsUrl) {
               $('#content').html('');
-              Object.keys(event.data).forEach(function(idpUrl) {
-                $('#content').append('<div class="account" style="width: 200px; background: #EEEEEE; padding: 5px 5px; margin-bottom: 10px;"><img src="' + idpUrl + '/.well-known/logo"></img><p>' + event.data[idpUrl].login + '</p><p>' + event.data[idpUrl].displayName + '</p><a class="btn" href="' +  idpUrl + samlRequest.acsUrl + '">Login</a></div>');
+              event.data.accounts.forEach(function (account) {
+                $('#content').append('<div class="account" style="width: 200px; background: #EEEEEE; padding: 5px 5px; margin-bottom: 10px;"><img src="' + account.origin + '/.well-known/logo"></img><p>' + account.login + '</p><p>' + account.displayName + '</p><a class="btn" href="' +  account.origin + samlRequest.acsUrl + '">Login</a></div>');
               });
             } else {
               $('#content').html('<h1>Not a valid SAMLRequest</h1>');

--- a/lib/start-account-storage.js
+++ b/lib/start-account-storage.js
@@ -1,0 +1,207 @@
+/**
+ * startAccountStorage(trustedRootDomains)
+ * 
+ * Initializes the AccountChooser iframe storage listener. Responds to messages 
+ * to store, get, and delete accounts across origins.
+ * 
+ * Example: 
+ * 
+ *   To listen to any valid message from okta.com and oktapreview.com:
+ * 
+ *   startAccountStorage([
+ *     'okta.com',
+ *     'oktapreview.com'
+ *   ]);
+ * 
+ * Messages are sent in the format:
+ * 
+ *   { messageType: {{message_type}},
+ *     any: 'other',
+ *     data: 'you need to send' }
+ * 
+ * Example:
+ * 
+ *   iframeWindow.postMessage(
+ *     { messageType: 'get_accounts' }, 
+ *     'https://login.okta.com'
+ *   );
+ * 
+ * Valid messages are 'get_accounts', 'remove_account', and 'login'.
+ */
+/* eslint max-statements:0 */
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(factory);
+  } 
+  else if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } 
+  else {
+    root.startAccountStorage = factory();
+  }
+}(this, function () {
+
+  var STORAGE_KEY = 'okta_accounts',
+      MAX_CACHE = 5;
+
+  /**
+   * Base storage access functions. AccountStorage uses the browser's native
+   * localStorage object to persist account data.
+   */
+
+  function getAccounts() {
+    try {
+      var accounts = localStorage.getItem(STORAGE_KEY);
+      return accounts ? JSON.parse(accounts) : [];
+    }
+    catch (e) {
+      return [];
+    }
+  }
+
+  function updateAccounts(fn) {
+    var accounts = fn(getAccounts());
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts));
+  }
+
+  function removeById(accounts, accountId) {
+    return accounts.filter(function (account) {
+      return account.id !== accountId;
+    });
+  }
+
+  /**
+   * Message handlers
+   *
+   * handlers is a map of data.messageType to processing functions. 
+   *
+   * Processing function:
+   *   F(e.data, e.origin) -> { responseMessage }
+   *
+   * The responseMessage is an optional object with any extra data that should
+   * be posted back to e.origin after the message has been processed, sans the
+   * response messageType (which is added later).
+   */
+
+  var handlers = {};
+
+  /**
+   * Stores a new account login. 
+   * 
+   * Expects:
+   * 
+   *   { messageType: 'login',
+   *     login: user login,
+   *     displayName: user display name }
+   * 
+   * Responds with:
+   * 
+   *   { messageType: 'processed_login' }
+   */
+  handlers['login'] = function (data, origin) {
+    var newAccount = {
+      id: origin + '::' + data.login,
+      login: data.login,
+      displayName: data.displayName,
+      origin: origin,
+      lastUpdated: new Date().toISOString() 
+    };
+    updateAccounts(function (accounts) {
+      // Remove any previous login by same user
+      var filtered = removeById(accounts, newAccount.id);
+
+      // Add new account to beginning of accounts list
+      filtered.unshift(newAccount);
+
+      // Only cache the most recent MAX_CACHE items
+      return filtered.slice(0, MAX_CACHE);
+    });
+  };
+
+  /**
+   * Gets stored accounts
+   * 
+   * Expects:
+   * 
+   *   { messageType: 'get_accounts' }
+   * 
+   * Responds with:
+   * 
+   *   { messageType: 'processed_get_accounts', 
+   *     accounts: [
+   *       { id: some distinct id,
+   *         displayName: user display name,
+   *         login: user login,
+   *         origin: the origin original login message came from,
+   *         lastUpdated: ISO date string when this account was last updated },
+   *       ...
+   *     ] }
+   */
+  handlers['get_accounts'] = function () {
+    return { accounts: getAccounts() };
+  };
+
+  /**
+   * Removes an account by id
+   * 
+   * Expects:
+   * 
+   *   { messageType: 'remove_account',
+   *     accountId: the account id }
+   * 
+   * Responds with:
+   * 
+   * { messageType: 'processed_remove_account' }
+   */
+  handlers['remove_account'] = function (data) {
+    updateAccounts(function (accounts) {
+      return removeById(accounts, data.accountId);
+    });
+  };
+
+  /**
+   * Validates whether the message should be handled.
+   * - Test if the message has a data object with a valid message handler
+   * - Test if the message is coming from a trusted root domain
+   */
+  function isValidMessage(trustedRootDomains, e) {
+    var origin = e.origin, 
+        data = e.data;
+    if (!data || typeof data !== 'object' || !handlers[data.messageType]) {
+      return false;
+    }
+    return trustedRootDomains.some(function (trustedRootDomain) {
+      var root = '.' + trustedRootDomain,
+          end = origin.substr(-1 * root.length),
+          isRootDomain = end === root,
+          isHttps = origin.substr(0, 8) === 'https://';
+      return isRootDomain && isHttps;
+    });
+  }
+
+  /**
+   * Invokes the appropriate processing function, and posts a response if 
+   * the message was successfully processed.
+   * 
+   * Note: All valid messages will post a response message to e.origin after 
+   * processing. The messageType will be processed_{{originalMessageType}}.
+   */
+  function handleMessage(trustedRootDomains, e) {
+    if (!isValidMessage(trustedRootDomains, e)) {
+      return;
+    }
+    var res = handlers[e.data.messageType](e.data, e.origin) || {};
+    res.messageType = 'processed_' + e.data.messageType;
+    e.source.postMessage(res, e.origin);
+  }
+
+  function startAccountStorage(trustedRootDomains) {
+    // Register the event listener to respond to incoming events immediately
+    // once this function is called.
+    var listener = handleMessage.bind(null, trustedRootDomains);
+    addEventListener('message', listener, false);
+  }
+
+  return startAccountStorage;
+
+}));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "account-chooser-sample",
+  "version": "0.0.1",
+  "description": "A technology sample that leverages [Web Messaging](https://html.spec.whatwg.org/multipage/comms.html#web-messaging) with hidden iframe to provide an account chooser across domains",
+  "scripts": {
+    "test": "eslint . && mocha"
+  },
+  "author": "",
+  "license": "Apache2.0",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "eslint": "^3.3.1",
+    "mocha": "^3.0.2",
+    "rewire": "^2.5.2",
+    "sinon": "^1.17.5"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ A technology sample that leverages [Web Messaging](https://html.spec.whatwg.org/
 Install packages
 
 `bower install`
+`npm install`
 
 This demo is currently coded to only allow requests from `*.okta.io:8081` origins.
 
@@ -17,26 +18,35 @@ This demo is currently coded to only allow requests from `*.okta.io:8081` origin
 
 ## Trusted Origin Whitelist
 
-This sample implements an origin whitelist that only allows trusted callers.  This is a security-best practice for cross-origin web messaging.
+This sample implements a root domain whitelist that only allows trusted callers.  This is a security-best practice for cross-origin web messaging.
 
 You can modify the whitelist by changing the following variables:
 
 index.html
 
 ```js
-var iframeOrigin = 'http://accounts.okta.io:8081';
+var iframeOrigin = 'https://accounts.okta.io:8081';
 ```
 
 discovery/iframe.html
 
 ```js
-var allowedOriginSuffix = '.okta.io:8081';
+var trustedRootDomains = ['okta.io:8081'];
 ```
 
 # Demo
 
-1. Launch `http://example.okta.io:8081` and add an account
-2. Launch `http://accounts.okta.io:8081` and refresh accounts
+1. Launch `https://example.okta.io:8081` and add an account
+2. Launch `https://accounts.okta.io:8081` and refresh accounts
 
-> You can use [http-server: a command-line http server](https://github.com/indexzero/http-server) if you don't have an existing web server on your developer machine
+> You can use [http-server: a command-line http server](https://github.com/indexzero/http-server) if you don't have an existing web server on your developer machine.
+>
+> **Note: You'll need to run http-server with the `--ssl` option.**
 
+## Development
+
+To run lint and unit tests:
+
+```bash
+[account-chooser-sample]$ npm test
+```

--- a/test/start-account-storage-spec.js
+++ b/test/start-account-storage-spec.js
@@ -1,0 +1,431 @@
+var expect = require('chai').expect,
+    sinon = require('sinon'),
+    rewire = require('rewire'),
+    startAccountStorage = rewire('../lib/start-account-storage');
+
+var ISO_DATE = '2016-08-16T23:04:15.778Z',
+    ISO_DATE_2 = '2016-08-16T23:04:20.888Z';
+
+function setup(options) {
+  options = options || {};
+
+  var registeredListener;
+  function setRegisteredListener(type, listener) {
+    registeredListener = listener;
+  }
+
+  var spies = {
+    addEventListener: sinon.spy(setRegisteredListener),
+    sourcePostMessage: sinon.spy(),
+    lsSetItem: sinon.spy(),
+    lsGetItem: sinon.stub().withArgs('okta_accounts')
+  };
+  startAccountStorage.__set__({
+    addEventListener: spies.addEventListener,
+    localStorage: {
+      setItem: spies.lsSetItem,
+      getItem: spies.lsGetItem
+    }
+  });
+
+  var isoDate = options.newAccountIsoDate || ISO_DATE;
+  sinon.stub(Date.prototype, 'toISOString').returns(isoDate);
+
+  startAccountStorage([
+    'okta.com',
+    'oktapreview.com',
+    'okta-emea.com'
+  ]);
+
+  return {
+    spies: spies,
+    sendMessage: function (message, sourceOrigin) {
+      var event = {
+        origin: sourceOrigin,
+        data: message,
+        source: {
+          postMessage: spies.sourcePostMessage
+        }
+      };
+      registeredListener(event);
+    }
+  };
+}
+
+function stubAccounts(test, accounts) {
+  var data = accounts ? JSON.stringify(accounts) : null;
+  test.spies.lsGetItem.onCall(0).returns(data);
+}
+
+function expectAccountsChange(options) {
+  var test = setup({ 
+    newAccountIsoDate: options.newAccountIsoDate
+  });
+
+  stubAccounts(test, options.startingLocalStorageState);
+  test.sendMessage(options.message.data, options.message.origin);
+  expect(test.spies.lsGetItem.callCount).to.equal(1);
+
+  var spy = test.spies.lsSetItem;
+  expect(spy.callCount).to.equal(1);
+  expect(spy.args[0][0]).to.equal('okta_accounts');
+  expect(JSON.parse(spy.args[0][1])).to.eql(options.finalLocalStorageSet);
+}
+
+function itDoesNotTrust(origin) {
+  it('does not trust ' + origin, function () {
+    var test = setup();
+    test.sendMessage({ messageType: 'get_accounts' }, origin);
+    expect(test.spies.sourcePostMessage.callCount).to.equal(0);
+    expect(test.spies.lsSetItem.callCount).to.equal(0); 
+  });
+}
+
+describe('startAccountStorage', function () {
+
+  afterEach(function () {
+    Date.prototype.toISOString.restore();
+  });
+
+  describe('General', function () {
+    it('registers message handler when startAccountStorage is called', function () {
+      var test = setup(),
+          spy = test.spies.addEventListener;
+      expect(spy.callCount).to.equal(1);
+      // Test the message type, and useCapture. Listener will be tested in
+      // subsequent tests.
+      expect(spy.args[0][0]).to.equal('message');
+      expect(spy.args[0][2]).to.equal(false);
+    });
+    it('does nothing if there is no valid messageType data', function () {
+      var test = setup();
+      test.sendMessage({}, 'https://a.okta.com');
+      expect(test.spies.sourcePostMessage.callCount).to.equal(0);
+      expect(test.spies.lsSetItem.callCount).to.equal(0);
+    });
+    itDoesNotTrust('http://a.okta.com');
+    itDoesNotTrust('https://evilokta.com');
+    itDoesNotTrust('https://evil.com');
+    itDoesNotTrust('https://a.evil.com');
+    itDoesNotTrust('https://a.okta.com.evil.com');
+    itDoesNotTrust('https://a.b.oktascom');
+    itDoesNotTrust('https://a.okta.com:8080');
+  });
+
+  describe('Messages', function () {
+
+    describe('login', function () {
+      it('adds account when there are no existing accounts', function () {
+        expectAccountsChange({
+          startingLocalStorageState: null,
+          message: {
+            origin: 'https://a.okta.com',
+            data: {
+              messageType: 'login',
+              displayName: 'Alexander Hamilton',
+              login: 'aham'
+            }
+          },
+          finalLocalStorageSet: [
+            {
+              id: 'https://a.okta.com::aham',
+              displayName: 'Alexander Hamilton',
+              login: 'aham',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            }
+          ]
+        });
+      });
+      it('adds account to front of list when there are existing accounts', function () {
+        expectAccountsChange({
+          startingLocalStorageState: [
+            {
+              id: 'https://a.okta.com::aham',
+              displayName: 'Alexander Hamilton',
+              login: 'aham',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            } 
+          ],
+          message: {
+            origin: 'https://b.okta.com',
+            data: {
+              messageType: 'login',
+              displayName: 'Thomas Jefferson',
+              login: 'tjeff'
+            }
+          },
+          finalLocalStorageSet: [
+            {
+              id: 'https://b.okta.com::tjeff',
+              displayName: 'Thomas Jefferson',
+              login: 'tjeff',
+              origin: 'https://b.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://a.okta.com::aham',
+              displayName: 'Alexander Hamilton',
+              login: 'aham',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            }
+          ]
+        });
+      });
+      it('removes any duplicated logins if user logs in with same account', function () {
+        expectAccountsChange({
+          startingLocalStorageState: [
+            {
+              id: 'https://b.okta.com::tjeff',
+              displayName: 'Thomas Jefferson',
+              login: 'tjeff',
+              origin: 'https://b.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://a.okta-emea.com::gwash',
+              displayName: 'George Washington',
+              login: 'gwash',
+              origin: 'https://a.okta-emea.com',
+              lastUpdated: ISO_DATE 
+            } 
+          ],
+          message: {
+            origin: 'https://a.okta-emea.com',
+            data: {
+              messageType: 'login',
+              displayName: 'George Washington',
+              login: 'gwash'
+            }
+          },
+          newAccountIsoDate: ISO_DATE_2,
+          finalLocalStorageSet: [
+            {
+              id: 'https://a.okta-emea.com::gwash',
+              displayName: 'George Washington',
+              login: 'gwash',
+              origin: 'https://a.okta-emea.com',
+              lastUpdated: ISO_DATE_2
+            }, 
+            {
+              id: 'https://b.okta.com::tjeff',
+              displayName: 'Thomas Jefferson',
+              login: 'tjeff',
+              origin: 'https://b.okta.com',
+              lastUpdated: ISO_DATE 
+            }
+          ]
+        });
+      });
+      it('only caches last 5 logins (FIFO)', function () {
+        expectAccountsChange({
+          startingLocalStorageState: [
+            {
+              id: 'https://b.okta.com::tjeff',
+              displayName: 'Thomas Jefferson',
+              login: 'tjeff',
+              origin: 'https://b.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://a.okta.com::aham',
+              displayName: 'Alexander Hamilton',
+              login: 'aham',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://a.okta.com::gwash',
+              displayName: 'George Washington',
+              login: 'gwash',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://d.okta.com::aburr',
+              displayName: 'Aaron Burr',
+              login: 'aburr',
+              origin: 'https://d.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://a.okta.com::bf',
+              displayName: 'Ben Franklin',
+              login: 'bf',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            }  
+          ],
+          message: {
+            origin: 'https://a.oktapreview.com',
+            data: {
+              messageType: 'login',
+              displayName: 'James Madison',
+              login: 'jmad'
+            }
+          },
+          finalLocalStorageSet: [
+            {
+              id: 'https://a.oktapreview.com::jmad',
+              displayName: 'James Madison',
+              login: 'jmad',
+              origin: 'https://a.oktapreview.com',
+              lastUpdated: ISO_DATE
+            },
+            {
+              id: 'https://b.okta.com::tjeff',
+              displayName: 'Thomas Jefferson',
+              login: 'tjeff',
+              origin: 'https://b.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://a.okta.com::aham',
+              displayName: 'Alexander Hamilton',
+              login: 'aham',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://a.okta.com::gwash',
+              displayName: 'George Washington',
+              login: 'gwash',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://d.okta.com::aburr',
+              displayName: 'Aaron Burr',
+              login: 'aburr',
+              origin: 'https://d.okta.com',
+              lastUpdated: ISO_DATE 
+            }
+          ]
+        });
+      });
+      it('posts a processed_login response', function () {
+        var test = setup(),
+            spy = test.spies.sourcePostMessage;
+        stubAccounts(test, null);
+        test.sendMessage({
+          messageType: 'login',
+          displayName: 'James Madison',
+          login: 'jmad'
+        }, 'https://a.okta.com');
+        expect(spy.callCount).to.equal(1);
+        expect(spy.args[0]).to.eql([
+          { messageType: 'processed_login' },
+          'https://a.okta.com'
+        ]);
+      });
+    });
+
+    describe('get_accounts', function () {
+      it('posts accounts in processed_get_accounts response when there are cached accounts', function () {
+        var test = setup(),
+            spy = test.spies.sourcePostMessage;
+
+        var accounts = [
+          {
+            id: 'https://a.okta.com::gwash',
+            displayName: 'George Washington',
+            login: 'gwash',
+            origin: 'https://a.okta.com',
+            lastUpdated: ISO_DATE 
+          },
+          {
+            id: 'https://d.okta.com::aburr',
+            displayName: 'Aaron Burr',
+            login: 'aburr',
+            origin: 'https://d.okta.com',
+            lastUpdated: ISO_DATE 
+          }
+        ];
+        stubAccounts(test, accounts);
+        test.sendMessage({ messageType: 'get_accounts' }, 'https://a.okta.com');
+
+        expect(spy.callCount).to.equal(1);
+        expect(spy.args[0]).to.eql([
+          { 
+            messageType: 'processed_get_accounts',
+            accounts: accounts
+          },
+          'https://a.okta.com'
+        ]);
+      });
+      it('posts an empty list when there are no cached accounts', function () {
+        var test = setup(),
+            spy = test.spies.sourcePostMessage;
+
+        stubAccounts(test, null);
+        test.sendMessage({ messageType: 'get_accounts' }, 'https://a.okta.com');
+
+        expect(spy.callCount).to.equal(1);
+        expect(spy.args[0]).to.eql([
+          { 
+            messageType: 'processed_get_accounts',
+            accounts: [] 
+          },
+          'https://a.okta.com'
+        ]);
+      });
+    });
+
+    describe('remove_account', function () {
+      it('removes an account by id', function () {
+        expectAccountsChange({
+          startingLocalStorageState: [
+            {
+              id: 'https://b.okta.com::tjeff',
+              displayName: 'Thomas Jefferson',
+              login: 'tjeff',
+              origin: 'https://b.okta.com',
+              lastUpdated: ISO_DATE 
+            },
+            {
+              id: 'https://a.okta.com::gwash',
+              displayName: 'George Washington',
+              login: 'gwash',
+              origin: 'https://a.okta.com',
+              lastUpdated: ISO_DATE 
+            } 
+          ],
+          message: {
+            origin: 'https://a.okta.com',
+            data: {
+              messageType: 'remove_account',
+              accountId: 'https://a.okta.com::gwash'
+            }
+          },
+          finalLocalStorageSet: [
+            {
+              id: 'https://b.okta.com::tjeff',
+              displayName: 'Thomas Jefferson',
+              login: 'tjeff',
+              origin: 'https://b.okta.com',
+              lastUpdated: ISO_DATE 
+            }
+          ]
+        });
+      });
+      it('posts a processed_remove_account response', function () {
+        var test = setup(),
+            spy = test.spies.sourcePostMessage;
+        stubAccounts(test, null);
+        test.sendMessage({
+          messageType: 'remove_account',
+          accountId: 'foo'
+        }, 'https://a.okta.com');
+        expect(spy.callCount).to.equal(1);
+        expect(spy.args[0]).to.eql([
+          { messageType: 'processed_remove_account' },
+          'https://a.okta.com'
+        ]);
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
- Responds to messages to add, list, and delete new accounts
- Supports multiple trusted origins
- Supports multiple accounts per origin
- Caps number of cached accounts to 5 (FIFO)
- Updated sample app to use new message format
- Tests + Linting
